### PR TITLE
Remove "extern C" from app_start

### DIFF
--- a/test/Series/main.cpp
+++ b/test/Series/main.cpp
@@ -142,7 +142,7 @@ void test() {
     }
     minar::Scheduler::postCallback(iSeries::Action(ser, &iSeries::go).bind(defer_check));
 }
-extern "C" void app_start(int argc, char *argv[])
+void app_start(int argc, char *argv[])
 {
     (void) argc;
     (void) argv;


### PR DESCRIPTION
app_start is not "extern C" anymore, so remove it to allow the test to
compile again.
